### PR TITLE
Release 3.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
           name: "OneSignal",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.1.1/OneSignal.xcframework.zip",
-          checksum: "5c65700baee859c75c5e8b91bba71256fea221b429c7c4e79570518c0fa73468"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.2.0/OneSignal.xcframework.zip",
+          checksum: "2b32941fb703c3e466a71e0309cdc968b744b5e4e20f3218c70d508312961058"
         )
     ]
 )


### PR DESCRIPTION
## iOS Launch URLs can now be suppressed entirely and handled outside of OneSignal #867
- A new plist option `OneSignal_suppress_launch_urls` can be added to prevent OneSignal from opening launch URLs so that they can be handled by applications separately

## Fixing XCFramework build issue for Arm simulators on Apple Silicon macs #873
- The OneSignal XCFramework will now build for both intel and Arm simulators on Apple Silicon macs

## Fix Firebase FCM conflict for non-OneSignal notifications #877 
- OneSignal will now properly forward non-OneSignal notifications to Firebase

