### PR TITLE
release 3.2.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
           name: "OneSignal",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.2.0/OneSignal.xcframework.zip",
-          checksum: "2b32941fb703c3e466a71e0309cdc968b744b5e4e20f3218c70d508312961058"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.2.1/OneSignal.xcframework.zip",
+          checksum: "0d0c7822d87afc9e87fe2a7389729ee8b07d3a078075e966ffdec117c1b8c893"
         )
     ]
 )


### PR DESCRIPTION
Fixes suppress launch URL boolean being flipped

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xcframework/6)
<!-- Reviewable:end -->
