### PR TITLE
Release 3.11.0-beta-01

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,58 @@ let package = Package(
     products: [
         .library(
             name: "OneSignal",
-            targets: ["OneSignal"]),
+            targets: ["OneSignalWrapper"]),
+        .library(
+            name: "OneSignalExtension",
+            targets: ["OneSignalExtensionWrapper"]),
     ],
     targets: [
+        .target(
+            name: "OneSignalWrapper",
+            dependencies: [
+                "OneSignal",
+                "OneSignalExtension",
+                "OneSignalOutcomes",
+                "OneSignalCore"
+            ],
+            path: "OneSignalWrapper"
+        ),
+        .target(
+            name: "OneSignalExtensionWrapper",
+            dependencies: [
+                "OneSignalExtension",
+                "OneSignalOutcomes",
+                "OneSignalCore"
+            ],
+            path: "OneSignalExtensionWrapper"
+        ),
+        .target(
+            name: "OneSignalOutcomesWrapper",
+            dependencies: [
+                "OneSignalOutcomes",
+                "OneSignalCore"
+            ],
+            path: "OneSignalOutcomesWrapper"
+        ),
         .binaryTarget(
           name: "OneSignal",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.10.2/OneSignal.xcframework.zip",
-          checksum: "b17aca2cb03bac87be5a219903eedda2ce3430c99949ce340fc00450b37c0a67"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.11.0-beta-01/OneSignal.xcframework.zip",
+          checksum: "49e24118ee0ba114bd715482cda14b7b37cf1f50410766e4efd0d5c696a885bf"
+        ),
+        .binaryTarget(
+          name: "OneSignalExtension",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.11.0-beta-01/OneSignalExtension.xcframework.zip",
+          checksum: "ae815d1cd77de5f2950c0fe2237a96d74b107b96836a2663dd434a24b428ae66"
+        ),
+        .binaryTarget(
+          name: "OneSignalOutcomes",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.11.0-beta-01/OneSignalOutcomes.xcframework.zip",
+          checksum: "ac65e226cb97e9272563be8973621ffc29a014b4354203b0df82499633d7c76a"
+        ),
+        .binaryTarget(
+          name: "OneSignalCore",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.11.0-beta-01/OneSignalCore.xcframework.zip",
+          checksum: "c6d1af6434d7eb97ad31056d84b2e180140c79612551f1b331aa88c82f8c96f4"
         )
     ]
 )


### PR DESCRIPTION
This Package.swift should be identical to the OneSignal-iOS-SDK Package.swift apart from the package name. We will no longer need to run update_swift_package.sh instead we can just copy the OneSignal-iOS-SDK Package.swift here and change the package name.

I don't think we will want to sunset this repository since it allows customers to pull in our SDK without cloning our entire iOS SDK repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xcframework/34)
<!-- Reviewable:end -->
