### PR TITLE
Updating package.swift for release 3.11.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,58 @@ let package = Package(
     products: [
         .library(
             name: "OneSignal",
-            targets: ["OneSignal"]),
+            targets: ["OneSignalWrapper"]),
+        .library(
+            name: "OneSignalExtension",
+            targets: ["OneSignalExtensionWrapper"]),
     ],
     targets: [
+        .target(
+            name: "OneSignalWrapper",
+            dependencies: [
+                "OneSignal",
+                "OneSignalExtension",
+                "OneSignalOutcomes",
+                "OneSignalCore"
+            ],
+            path: "OneSignalWrapper"
+        ),
+        .target(
+            name: "OneSignalExtensionWrapper",
+            dependencies: [
+                "OneSignalExtension",
+                "OneSignalOutcomes",
+                "OneSignalCore"
+            ],
+            path: "OneSignalExtensionWrapper"
+        ),
+        .target(
+            name: "OneSignalOutcomesWrapper",
+            dependencies: [
+                "OneSignalOutcomes",
+                "OneSignalCore"
+            ],
+            path: "OneSignalOutcomesWrapper"
+        ),
         .binaryTarget(
           name: "OneSignal",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.10.3/OneSignal.xcframework.zip",
-          checksum: "1db61d448584500ce9f771ba84a394f6617c88a1a9455bd48bfd79f23d7f88a9"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.11.0/OneSignal.xcframework.zip",
+          checksum: "ad6fb431e9518d06d2548b0b44b9cff007d3e2c8c321715894e524b3fe53a459"
+        ),
+        .binaryTarget(
+          name: "OneSignalExtension",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.11.0/OneSignalExtension.xcframework.zip",
+          checksum: "2972494c949760e91a2e48ed35e906bce0b394be1a68b99a5eac5548ebfee8ac"
+        ),
+        .binaryTarget(
+          name: "OneSignalOutcomes",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.11.0/OneSignalOutcomes.xcframework.zip",
+          checksum: "c482cb8d8fac8c6e1f53883792aa038d5360fb2395a39a6db5f08e907c77ddd9"
+        ),
+        .binaryTarget(
+          name: "OneSignalCore",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.11.0/OneSignalCore.xcframework.zip",
+          checksum: "dad6f52b10815cac20950b91f7a90402a3ac91e31965589a40453b2d646679c7"
         )
     ]
 )


### PR DESCRIPTION
This repo no longer needs to run any build scripts we simply copy over the OneSignal-iOS-SDK package.swift and change the package name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xcframework/36)
<!-- Reviewable:end -->
