### PR TITLE
Release 5.0.0 alpha 01

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,22 +7,47 @@ let package = Package(
     name: "OneSignalXCFramework",
     products: [
         .library(
-            name: "OneSignal",
-            targets: ["OneSignalWrapper"]),
+            name: "OneSignalFramework",
+            targets: ["OneSignalFrameworkWrapper"]),
         .library(
             name: "OneSignalExtension",
             targets: ["OneSignalExtensionWrapper"])
     ],
     targets: [
         .target(
-            name: "OneSignalWrapper",
+            name: "OneSignalFrameworkWrapper",
             dependencies: [
-                "OneSignal",
+                "OneSignalFramework",
+                "OneSignalUser",
+                "OneSignalNotifications",
+                "OneSignalExtension",
+                "OneSignalOutcomes",
+                "OneSignalOSCore",
+                "OneSignalCore"
+            ],
+            path: "OneSignalFrameworkWrapper"
+        ),
+        .target(
+            name: "OneSignalUserWrapper",
+            dependencies: [
+                "OneSignalUser",
+                "OneSignalNotifications",
+                "OneSignalExtension",
+                "OneSignalOutcomes",
+                "OneSignalOSCore",
+                "OneSignalCore"
+            ],
+            path: "OneSignalUserWrapper"
+        ),
+        .target(
+            name: "OneSignalNotificationsWrapper",
+            dependencies: [
+                "OneSignalNotifications",
                 "OneSignalExtension",
                 "OneSignalOutcomes",
                 "OneSignalCore"
             ],
-            path: "OneSignalWrapper"
+            path: "OneSignalNotificationsWrapper"
         ),
         .target(
             name: "OneSignalExtensionWrapper",
@@ -41,25 +66,48 @@ let package = Package(
             ],
             path: "OneSignalOutcomesWrapper"
         ),
+        .target(
+            name: "OneSignalOSCoreWrapper",
+            dependencies: [
+                "OneSignalOSCore",
+                "OneSignalCore"
+            ],
+            path: "OneSignalOSCoreWrapper"
+        ),
         .binaryTarget(
-          name: "OneSignal",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.3/OneSignal.xcframework.zip",
-          checksum: "771478cf9e7801adeb832ee37d6a1b24f41a009d69e3654b22a3ff9c1d48d1da"
+          name: "OneSignalFramework",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-alpha-01/OneSignalFramework.xcframework.zip",
+          checksum: "4f50e9587156902b31d7141860252585203b695d1021e6e4ab0043e06a155a9a"
+        ),
+        .binaryTarget(
+          name: "OneSignalUser",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-alpha-01/OneSignalUser.xcframework.zip",
+          checksum: "7765bba3068471b937f334f430c52b3db896454804374b4f5f9e7ae318215cb2"
+        ),
+        .binaryTarget(
+          name: "OneSignalNotifications",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-alpha-01/OneSignalNotifications.xcframework.zip",
+          checksum: "d0dfc93d949bba2e93b200ff21ec495e0cc26734439502f4f9328c5a021856d8"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.3/OneSignalExtension.xcframework.zip",
-          checksum: "90178e770caca0dd22bb6816bbbe472b32cdc51afe8108dd3b40776a3b119496"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-alpha-01/OneSignalExtension.xcframework.zip",
+          checksum: "4c5f46b7e2c05cc92e2dea080a8620909d6bf3873bc1bb0580831a1ed0084cb5"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.3/OneSignalOutcomes.xcframework.zip",
-          checksum: "9c9039db524e7e602f3e428c157b2be6bb9dd25283d7447ef9b158c4fa46a9e9"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-alpha-01/OneSignalOutcomes.xcframework.zip",
+          checksum: "f34e8b283a3c5db469164d5752f11cc9c464113bf04aa2531517241f8596cb0d"
+        ),
+        .binaryTarget(
+          name: "OneSignalOSCore",
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-alpha-01/OneSignalOSCore.xcframework.zip",
+          checksum: "bb4e322248b6c9c93eb478fef44416417aaf6968333702dc9e5e9dcee07e614f"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.3/OneSignalCore.xcframework.zip",
-          checksum: "2ae02305d3e7cc7a571df93e70efdef4b8d2056100f196bd766c3041637d3b9a"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-alpha-01/OneSignalCore.xcframework.zip",
+          checksum: "9649d2269722cf60b03f9c55dd9af5f65b1933b28852e9ed1a6bbb202dcb1150"
         )
     ]
 )


### PR DESCRIPTION
In this major version alpha release for the OneSignal SDK, we are making a significant shift from a device-centered model to a user-centered model. A user-centered model allows for more powerful omni-channel integrations within the OneSignal platform.

Find our [migration guide here ](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/major_release_5.0.0/MIGRATION_GUIDE.md
)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-xcframework/53)
<!-- Reviewable:end -->
