### PR TITLE
Release 5.0.0-beta-06

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,48 +105,48 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalFramework.xcframework.zip",
-          checksum: "671086520e15751ae5fb5ac0b7721cb2c6f317c8701e94d90f049c054ba1ad8e"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalFramework.xcframework.zip",
+          checksum: "f0c7a65cbcab6d82e3bd241b19c6cd4a0d9fc446e6f8f4c657322066dc547ee8"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalInAppMessages.xcframework.zip",
-          checksum: "267a1d2f4a2d20d5db460318b4ede69f9c9e307718d7ad3f421fe608ec0f9b58"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalInAppMessages.xcframework.zip",
+          checksum: "5c48f1a16166f043eaf510e83d77428c6dab6b27b4544ad8a9fc438a442a7d33"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalLocation.xcframework.zip",
-          checksum: "6be5d1ffc7adda9859b94f8a12eda014b6331367183947313793d0ed114498f2"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalLocation.xcframework.zip",
+          checksum: "fd711bec318dcb9b1fc8087ae83e70f3e39c886d983d258ca96aa1c7241e7a9b"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalUser.xcframework.zip",
-          checksum: "c4a2e83ca7c0e83ece1657dd0888b8c187975f0045ac4ad47126cfc5caa7fa4d"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalUser.xcframework.zip",
+          checksum: "5bf8f7807c8ddabe2f55d7284e3cc084bf0bbf7b8fc21c3d5ea7890b99c5725c"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalNotifications.xcframework.zip",
-          checksum: "e270c4f564a0f7287c0dca68a76fd27ad4c97026df6a887240242a0d239350bd"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalNotifications.xcframework.zip",
+          checksum: "d377cee1c5b0f208a4ef6eedaf36b59ae966cc7db25e0074e46ec3f6294a8d41"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalExtension.xcframework.zip",
-          checksum: "b9be2f25732eed4cdfec5c9724210b88b621fe15900055e1559074f9cdaa6173"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalExtension.xcframework.zip",
+          checksum: "38ed96d71694f425a9aaae9226f58e2630a0e841fd2d598b1fa75a14758e998f"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalOutcomes.xcframework.zip",
-          checksum: "32e56bf8ed1ff0fcde63225cd640e402c5290b212f96d77fab0cabbb12f44a52"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalOutcomes.xcframework.zip",
+          checksum: "7b273ca6b35fd5f9cce8dfdd9076b495950a12d96f543e02e133dde5b1d0e4f5"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalOSCore.xcframework.zip",
-          checksum: "d3d6a036f6bd3659d698ffd8ff1b1a80963b7b45eb1ae17a530466bd567820f3"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalOSCore.xcframework.zip",
+          checksum: "e665db8193cd76d79487b64deff9361fe9798240b74b748cbac09311607b3484"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-05/OneSignalCore.xcframework.zip",
-          checksum: "d92bc22675985f85f24ef5e6f3e4ad433f67abe5e985aa3e23d6784e56c04584"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalCore.xcframework.zip",
+          checksum: "9e08924dfc49453c75b01389bb8bb2eadb571b53d722a334c0889dc8e0de2348"
         )
     ]
 )


### PR DESCRIPTION
🚧 Beta release. 🚧

In this major version beta release for the OneSignal SDK, we are making a significant shift from a device-centered model to a user-centered model. A user-centered model allows for more powerful omni-channel integrations within the OneSignal platform.

For information please see the [migration guide](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/major_release_5.0.0/MIGRATION_GUIDE.md).

## What's Changed Since beta 5
**Fix a podspec build issue**
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1281

**Full Changelog**: https://github.com/OneSignal/OneSignal-iOS-SDK/compare/5.0.0-beta-05...5.0.0-beta-06

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/63)
<!-- Reviewable:end -->
