### PR TITLE
Updating package.swift for release 3.12.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,23 +43,23 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignal",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.5/OneSignal.xcframework.zip",
-          checksum: "ae6944383b688f85b759b52fefbfea1f788245f03248c1961e5af60b1b062aa8"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.6/OneSignal.xcframework.zip",
+          checksum: "48d79753e67f2ad802e1cc738dbdce1a2d24517f9812e67d76c2387965bc9c5d"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.5/OneSignalExtension.xcframework.zip",
-          checksum: "ccf3ea1bdec0cfe706a36ac78346beda9aa118eaccedbeccd79f7fce1ac8309c"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.6/OneSignalExtension.xcframework.zip",
+          checksum: "22d050a8e2d41dd7cea7331bf98363ff264c38175128df0f14a3c7d86c8156ae"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.5/OneSignalOutcomes.xcframework.zip",
-          checksum: "11c0417695e5a488286651ab67850fa4509d3825a2f048f925614797e7083d5f"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.6/OneSignalOutcomes.xcframework.zip",
+          checksum: "4d6e08640dc49986424caa0163afa022faa4020dc4e642812fc9a04d57dca12b"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.5/OneSignalCore.xcframework.zip",
-          checksum: "4f93b420d2421b65681d00a3b95de8c0b0057a678f4ededa5ffc772fc13f4442"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.6/OneSignalCore.xcframework.zip",
+          checksum: "0b9ac1abd8fb242be1597939fbd3d6b807bad15253c22bea05936789cd0fbd6b"
         )
     ]
 )


### PR DESCRIPTION
🐛 Bug Fixes

Fix swizzling subclass of already swizzled class (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1284)
Always remove the window when an InApp Message is dismissed ([Always remove the window when an IAM is dismissed  #1276](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1284))
🧰 Improvements

Make web views inspectable (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1286) https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1292

Other Notes
This is the first 3.X.X version built using Xcode 14.1 build. This requires that we remove the armv7s architecture from supported architectures. It also requires that our minimum deployment target is bumped to iOS 11.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/65)
<!-- Reviewable:end -->
