### PR TITLE
Update package.swift for release 5.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,48 +105,48 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalFramework.xcframework.zip",
-          checksum: "f0c7a65cbcab6d82e3bd241b19c6cd4a0d9fc446e6f8f4c657322066dc547ee8"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalFramework.xcframework.zip",
+          checksum: "e9d9cba7604dc4a9e75592689ca2944d774bebcd68e4c8f3796d2f559e6919e1"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalInAppMessages.xcframework.zip",
-          checksum: "5c48f1a16166f043eaf510e83d77428c6dab6b27b4544ad8a9fc438a442a7d33"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalInAppMessages.xcframework.zip",
+          checksum: "639e8b11bf77cf438b021e2f06edde42b34bc718c59947685aada28b59e8f62b"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalLocation.xcframework.zip",
-          checksum: "fd711bec318dcb9b1fc8087ae83e70f3e39c886d983d258ca96aa1c7241e7a9b"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalLocation.xcframework.zip",
+          checksum: "118e937eeb43654bf4b10c0d70985a81985530a8e43e3992af7b728603349d82"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalUser.xcframework.zip",
-          checksum: "5bf8f7807c8ddabe2f55d7284e3cc084bf0bbf7b8fc21c3d5ea7890b99c5725c"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalUser.xcframework.zip",
+          checksum: "9153935350d7fdd2a7a530723cb678a49fda662b6098cb8b4b354db9c49911aa"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalNotifications.xcframework.zip",
-          checksum: "d377cee1c5b0f208a4ef6eedaf36b59ae966cc7db25e0074e46ec3f6294a8d41"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalNotifications.xcframework.zip",
+          checksum: "fd883e8944a1530335601c944c5d22c7ccf1d80c0b106031e2f83d8489040597"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalExtension.xcframework.zip",
-          checksum: "38ed96d71694f425a9aaae9226f58e2630a0e841fd2d598b1fa75a14758e998f"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalExtension.xcframework.zip",
+          checksum: "cd50a84aeb99ffabf561976c2576e47fde4411a38eb071d9bd7624a3e4d10534"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalOutcomes.xcframework.zip",
-          checksum: "7b273ca6b35fd5f9cce8dfdd9076b495950a12d96f543e02e133dde5b1d0e4f5"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalOutcomes.xcframework.zip",
+          checksum: "9e7c86c7e9fd1f070b9fc25327a5a9482390819995f2276cbe25760f263972e7"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalOSCore.xcframework.zip",
-          checksum: "e665db8193cd76d79487b64deff9361fe9798240b74b748cbac09311607b3484"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalOSCore.xcframework.zip",
+          checksum: "7e69eda2258da9c33b7c2368480e4b7620b7be2e1ded950a44e2d4788eb88bbd"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0-beta-06/OneSignalCore.xcframework.zip",
-          checksum: "9e08924dfc49453c75b01389bb8bb2eadb571b53d722a334c0889dc8e0de2348"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.0/OneSignalCore.xcframework.zip",
+          checksum: "cf07a0e4914c21b29f4475e861e11a3ecb6173dbda1592764a03f06127fe4095"
         )
     ]
 )


### PR DESCRIPTION
# ⚠️ This is a major release which contains breaking API changes.

In this major version release for the OneSignal iOS SDK, we are making a significant shift from a device-centered model to a user-centered model. A user-centered model allows for more powerful omni-channel integrations within the OneSignal platform.

For information please see the [migration guide](https://github.com/OneSignal/OneSignal-iOS-SDK/blob/major_release_5.0.0/MIGRATION_GUIDE.md).

## What's Changed Since beta 6

Push Subscription Update Fixes [#1289 
](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1289)Session Influence Updates [#1288 ](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1288)
Handle errors for Creating a User [#1290 ](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1290)
Fix displaying multiple In App Messages for the same trigger [#1294](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1294) 
Overhaul background tasks [#1300](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1300)


Full Changelog: https://github.com/OneSignal/OneSignal-iOS-SDK/compare/5.0.0-beta-06...5.0.0