### PR TITLE
Release 5.0.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,48 +105,48 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalFramework.xcframework.zip",
-          checksum: "795bae10607862e289ae655410cdcf5ec04ea373498059c56c7a7bff202d896e"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalFramework.xcframework.zip",
+          checksum: "d574fa4b1cc68b1a47bb4ee7997e7991c68f8fb9e1e1d8bb7d49bb87c228ee15"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalInAppMessages.xcframework.zip",
-          checksum: "b1ab563998fbdef3cf821323c887198776a0ec3afecbf3c974dafb319a8c124f"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalInAppMessages.xcframework.zip",
+          checksum: "1b263627a26d53e0ff8d708d32538f253de3665e2ee439601a278238f3bbb3a9"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalLocation.xcframework.zip",
-          checksum: "f1d9a364029c3c272d2a75f7d7bc7a2e44ffe71e6c11561c35be78953a8f54d0"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalLocation.xcframework.zip",
+          checksum: "898cf4bbf309c255d92ded42f0199c04202cdf0a91b6ebdc2065539c2ed5c151"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalUser.xcframework.zip",
-          checksum: "4e808e37fec711d9a0cbdd0e88d36c00e896308210cb1bff6addf76ce8a8b501"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalUser.xcframework.zip",
+          checksum: "80b2b4ca889f010884fd61efbe6ff93c369aed6850a588f020b2376ea7ab76c9"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalNotifications.xcframework.zip",
-          checksum: "35d6a889699ce51624a10c0b8bcab883fb32478b12ef5b53d78ef5eb0b0c06e2"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalNotifications.xcframework.zip",
+          checksum: "deb0a6402bc96bfb1971beffbb4f83704f32c2c7dbcd8bd1283ccbedc2813c4b"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalExtension.xcframework.zip",
-          checksum: "9ea67142691d02adad6f587d1fcc3c4341091117eb27e60f6d88128ec8697b37"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalExtension.xcframework.zip",
+          checksum: "c2ed61f6d894de5e2731034240497b2b3c2516089e641b0d80ffc9cb8d5c85d5"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalOutcomes.xcframework.zip",
-          checksum: "ef1891e4367dab51495a786d52725e57eaa2a192174ac7390131324dbb5c49d9"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalOutcomes.xcframework.zip",
+          checksum: "67f3538337b9de030753588105ed6974b62e9c46ee36f45919ca3ecd99a81a04"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalOSCore.xcframework.zip",
-          checksum: "c9eca6e786c9a604041ec6f0ea12f8ba0ace9da1ecabc26ec074a562c1fa2edf"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalOSCore.xcframework.zip",
+          checksum: "c8367f2e7842224655b3822a8b65fa648ecabf51d7589c786f532cc976c9b3fd"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.3/OneSignalCore.xcframework.zip",
-          checksum: "f776111be9165148430dc4797fc97338250c9d65be701af4b5e97276219a71cc"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.0.4/OneSignalCore.xcframework.zip",
+          checksum: "29762aa07d4ce0cc2f1cdea9fa1ab5d4072f43ebf88796ee3f00fd1b98f0e5d6"
         )
     ]
 )


### PR DESCRIPTION
Note: validated the 9 zips checksums in Package.swift 

## A re-do of release 5.0.3 because it was released with xcode 15 tools

## What's Changed
**🐛 Bug Fixes**
* Fix badge clearing when calling clearAll in https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1335
* Fix crash with direct influence but nil direct id https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1327
* Fix forwarding notification opens from non onesignal notifs https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1326


**Full Changelog**: https://github.com/OneSignal/OneSignal-iOS-SDK/compare/5.0.2...5.0.4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/74)
<!-- Reviewable:end -->
