### PR TITLE
Release 5.1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,48 +105,48 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalFramework.xcframework.zip",
-          checksum: "9f1b8c8c3cba585b5861d3b04df167a5e74a48400e7b6d4db7b61767b9c8bb46"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalFramework.xcframework.zip",
+          checksum: "6af9aeeda23d25953aa2d74b309a30208dbad559c767695f10e18cddee664bd7"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalInAppMessages.xcframework.zip",
-          checksum: "92212c029622ac585cb55ac29f36f68ce9c1f50bf500c33008477f96b229f7e1"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalInAppMessages.xcframework.zip",
+          checksum: "3b3da7782b3db958036883037ca788cc2364086f268f32d042b5120e70d6dab2"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalLocation.xcframework.zip",
-          checksum: "8b1fee64e9dcebc85d5220e5600be23e560895f25aa2d6d02472d7ddb2bfd899"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalLocation.xcframework.zip",
+          checksum: "d47a9bc2d633889c16026160ec161bc73471bd29bb99da6c0657c2b3cbd82855"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalUser.xcframework.zip",
-          checksum: "04c4226583588782a3c7eab7fc5432e5c2e5d3f7b93dbe035f11420d040edba6"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalUser.xcframework.zip",
+          checksum: "2f5acd46e71c10425f49880be0b1beed48fdc40b05f9545153f9bd8226899173"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalNotifications.xcframework.zip",
-          checksum: "2383ae631e80b06f42557eff3f06a41a3e2614dccd854b767950e975ded70838"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalNotifications.xcframework.zip",
+          checksum: "634dec194bf0bbee746606baf8d8742c760d131d7e39e7395e1e0d100115fc9d"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalExtension.xcframework.zip",
-          checksum: "9cc6c0e0b9090c7c9816157e4ba1193194f132ebf0dae6c28533c2de3fb7c5dd"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalExtension.xcframework.zip",
+          checksum: "424eb4229074afb25e0fa4cb44d900597fd3c057e7d4c864ea5c034e60701137"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalOutcomes.xcframework.zip",
-          checksum: "91e675c23450803d96554820dbe5a1d6aec4157364699bb141a58f24106ee7fc"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalOutcomes.xcframework.zip",
+          checksum: "f96a931893acc89791481b9978b9874725ccb70c079058fea5365150843ca51f"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalOSCore.xcframework.zip",
-          checksum: "a7e039b2a43bb88d2e1de3feeac977db5cf941959379ef7a196813a4f9a048da"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalOSCore.xcframework.zip",
+          checksum: "b8e2e5dbcc0ef0b3634071fa0d3c8404fb4475c6112e98f033d4bcd675ce33d4"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.0/OneSignalCore.xcframework.zip",
-          checksum: "b78ec86cbed1f271fe868eaa4cdce6a2ee7de5be514548f9d21e0b122653cde3"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalCore.xcframework.zip",
+          checksum: "801123d53c8aadf51290800361a50394651c2b2852935739b9a7e640ad8def16"
         )
     ]
 )


### PR DESCRIPTION
## What's Changed

**⚠️ Behavior Changes**
* When you call the `jsonRepresentation` method of `OSPushSubscriptionState`, if a property is null, the value will now be `""` instead of the string literal `"nil"` [#1373](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1373)
    
**🐛 Bug Fixes & Misc Improvements**
* Rename internal method that was called `setSharedInstance` to workaround false App Store flagging [#1375](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1375)
* Improve Swift concurrency safety to address crash reports in production [#1376](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1376)
* For our server: Add `OneSignal-Subscription-Id` to Create User request which improves `last_active` data [#1372
](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1372)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/77)
<!-- Reviewable:end -->
