### PR TITLE
Release 5.1.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,48 +105,48 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalFramework.xcframework.zip",
-          checksum: "6af9aeeda23d25953aa2d74b309a30208dbad559c767695f10e18cddee664bd7"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalFramework.xcframework.zip",
+          checksum: "adc26123bc87ec3a1b527d474f04aec6b65d38589d264b7d44c60c4d404b24bd"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalInAppMessages.xcframework.zip",
-          checksum: "3b3da7782b3db958036883037ca788cc2364086f268f32d042b5120e70d6dab2"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalInAppMessages.xcframework.zip",
+          checksum: "195ce6acc69ea51dba1d7422dacac20a9159ebb0975c7e2caaf168a95e2be781"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalLocation.xcframework.zip",
-          checksum: "d47a9bc2d633889c16026160ec161bc73471bd29bb99da6c0657c2b3cbd82855"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalLocation.xcframework.zip",
+          checksum: "1c18250d977e039842dcb461376d44abadb990a9ddf97ce2f529046b12692f83"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalUser.xcframework.zip",
-          checksum: "2f5acd46e71c10425f49880be0b1beed48fdc40b05f9545153f9bd8226899173"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalUser.xcframework.zip",
+          checksum: "8158d6da31cff5d138f5ee662796739ad2e8805ea0df7ec104c80e6b4150191a"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalNotifications.xcframework.zip",
-          checksum: "634dec194bf0bbee746606baf8d8742c760d131d7e39e7395e1e0d100115fc9d"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalNotifications.xcframework.zip",
+          checksum: "2334e9ae0c27b9785981ea59e5f4e873ac3017d872efc20601241e7e1b50b912"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalExtension.xcframework.zip",
-          checksum: "424eb4229074afb25e0fa4cb44d900597fd3c057e7d4c864ea5c034e60701137"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalExtension.xcframework.zip",
+          checksum: "4f01aaea6387394bfea155e63d2e6505c6d0cfd4a71b499e29b74eeec80f67b2"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalOutcomes.xcframework.zip",
-          checksum: "f96a931893acc89791481b9978b9874725ccb70c079058fea5365150843ca51f"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalOutcomes.xcframework.zip",
+          checksum: "607aa241f8b3f8d14f9cc2518bc15ff9c6d55c9ecb3355aaa1d16aaffacf7a81"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalOSCore.xcframework.zip",
-          checksum: "b8e2e5dbcc0ef0b3634071fa0d3c8404fb4475c6112e98f033d4bcd675ce33d4"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalOSCore.xcframework.zip",
+          checksum: "616c212fafea9cdedb164d49d7e295613c079d741a789c8519f5ed9ba36dbff5"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.1/OneSignalCore.xcframework.zip",
-          checksum: "801123d53c8aadf51290800361a50394651c2b2852935739b9a7e640ad8def16"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.2/OneSignalCore.xcframework.zip",
+          checksum: "f0e965e30c40f52e8b47cca89d46a26c441d3d02b74a3c126d7360d45bf51ed8"
         )
     ]
 )


### PR DESCRIPTION
## What's Changed

**⚠️ Behavior Changes**
* When you call the `jsonRepresentation` method of `OSPushSubscriptionState`, if a property is null, the value will now be `""` instead of the string literal `"nil"` [#1373](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1373)
    
**🐛 Bug Fixes & Misc Improvements**
* Rename internal method that was called `setSharedInstance` to workaround false App Store flagging [#1375](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1375)
* Improve Swift concurrency safety to address crash reports in production [#1376](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1376)
* For our server: Add `OneSignal-Subscription-Id` to Create User request which improves `last_active` data [#1372
](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1372)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/78)
<!-- Reviewable:end -->
