### PR TITLE
Release 3.12.8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,23 +43,23 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignal",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.6/OneSignal.xcframework.zip",
-          checksum: "48d79753e67f2ad802e1cc738dbdce1a2d24517f9812e67d76c2387965bc9c5d"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.8/OneSignal.xcframework.zip",
+          checksum: "deaee318d7bd13202d77f884bf1a8f5c2f77b72dca82a1b5a154da2b3bc800a6"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.6/OneSignalExtension.xcframework.zip",
-          checksum: "22d050a8e2d41dd7cea7331bf98363ff264c38175128df0f14a3c7d86c8156ae"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.8/OneSignalExtension.xcframework.zip",
+          checksum: "60e00108ee2da1f5e108f8f9925537e160b83e84dc1b38e539e6965181ba5ad6"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.6/OneSignalOutcomes.xcframework.zip",
-          checksum: "4d6e08640dc49986424caa0163afa022faa4020dc4e642812fc9a04d57dca12b"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.8/OneSignalOutcomes.xcframework.zip",
+          checksum: "e44c272bb897b916e861a853480436a82017d4f92db44757bee61d4a71f7f55c"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.6/OneSignalCore.xcframework.zip",
-          checksum: "0b9ac1abd8fb242be1597939fbd3d6b807bad15253c22bea05936789cd0fbd6b"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/3.12.8/OneSignalCore.xcframework.zip",
+          checksum: "37850a5cb96c6e74a58e248a16b336adf7df4ebe6efc4133dfef57b7ac946714"
         )
     ]
 )


### PR DESCRIPTION
**🎉 New Features**

- Added privacy manifests in https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1360
- This release is also signed by the OneSignal certificate

------
Note: Looks like 3.12.7 was never released on OneSignal-XCFramework

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/80)
<!-- Reviewable:end -->
