### PR TITLE
Update Release 5.1.6 with new xcframework zips

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,47 +106,47 @@ let package = Package(
         .binaryTarget(
           name: "OneSignalFramework",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalFramework.xcframework.zip",
-          checksum: "43d7fc6f109eeffa2b0d36ba7bdf16889ea3422a91408fc0b13467e9dd87bbe5"
+          checksum: "d3583670e3229536833c319cbc8575732b4585355a85ab7ccb7f9946dea1d5d0"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalInAppMessages.xcframework.zip",
-          checksum: "9cb6f66a97d6fbe2023bd9820fba94f46529989c7b7e56744c20247117e33000"
+          checksum: "670793182248a8ec6cf16b2021025e4710f4ed9f9c324bcc89f636b11e7053c8"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalLocation.xcframework.zip",
-          checksum: "debbbc361c3a008dcdc7cbd770e69d2de29586034e837b38844cdecb7772720a"
+          checksum: "bbd9c67456183273e9e6fd586f333e27ea6264aedcee81aad403bba31b1f4c81"
         ),
         .binaryTarget(
           name: "OneSignalUser",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalUser.xcframework.zip",
-          checksum: "c15b54b73698ce32919e650eb7c704b7eaf37bfcc0919af7ce9368146ef50b9a"
+          checksum: "be12dfe269598613b19f7b7c8010a544a6a6c3d7d94313fc8bd358d2607a11ce"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalNotifications.xcframework.zip",
-          checksum: "2b01bcaf2e82ad54a894ea4d3a84e351df690214a1cabbe4c17d60e998318771"
+          checksum: "d0709d49ce38bf802ea75ea1c6942f583d8e1394791a27ea0b47cda8deffee9e"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalExtension.xcframework.zip",
-          checksum: "15b4a70e863f14392293644dfb320732e671a5477f7008bdced03925cd489ae8"
+          checksum: "3851971f0abbac0c4ba92bc1b663e509d6dd5f7cb40b2b23d066fdab90b67f03"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalOutcomes.xcframework.zip",
-          checksum: "ccafedfe59b757120f7e1ffcbd09d87f604b4f65926360af2a568099e2c8f93d"
+          checksum: "61f11ff803e8e1aa7481737bb49127f8211463eca84761840d5d2460d768d0d8"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalOSCore.xcframework.zip",
-          checksum: "44a470e9c6af71c41ec17effbffc6c2cb2b247dfc5dc68d7ee8a2032642c2809"
+          checksum: "965312f35acb180f6eddffc7d40ca712e48fb32c576ac09d6fc6d7c23ce46871"
         ),
         .binaryTarget(
           name: "OneSignalCore",
           url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.1.6/OneSignalCore.xcframework.zip",
-          checksum: "73049232bc7994f4d69156414ea15158327298b4e819615465819e8cd6d70445"
+          checksum: "46be3f316ed4506ab88d787821476572c9b016d7778beaa60a59a607c6c223e7"
         )
     ]
 )


### PR DESCRIPTION
* The zips were previously generated before the xcframeworks were signed.
* These are generated after the xcframeworks are signed

Only affects SPM
Tested cocoapods still works with release 5.1.6
Tested SPM still works with release 5.1.6 after these changes, and unzipping shows the code signatures

https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1422

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/87)
<!-- Reviewable:end -->
