### PR TITLE
Release 5.2.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -114,53 +114,53 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalFramework.xcframework.zip",
-          checksum: "d1c1393e2ae4465d1136239857d7534d32acac5a5bd06d852a20ab8fe895a436"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalFramework.xcframework.zip",
+          checksum: "31aa6043d0ad839c2edeab67201390aa209e42879872552d6909e6300c446519"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalInAppMessages.xcframework.zip",
-          checksum: "0630f0fde2d87e766fd6ee8f32facda3479ea0c0962797d46be42f7f7b62aeb1"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalInAppMessages.xcframework.zip",
+          checksum: "b1ebddda90b3be09586794928b214bd2a7886f242920e3e904f287f9b007b1ed"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalLocation.xcframework.zip",
-          checksum: "4a859e2b430e980f83da42d4766d69fe9bd3b415eff262732e37a6f77158da05"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalLocation.xcframework.zip",
+          checksum: "f8d82c8d7145b5525cb92c8bc693106af4254f15c9e919061f5a4109a0623078"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalUser.xcframework.zip",
-          checksum: "d75fde367aa92b379205bd65a80d0a9f2827f31921b031feb36d3b9f9a1147df"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalUser.xcframework.zip",
+          checksum: "6595a504ba8334b650444281cf354cecbabdf6ce2d6e7f34cf4dce9a999fe804"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalNotifications.xcframework.zip",
-          checksum: "d692204ef875e915161b23960d9ba540c1ad3b249023218de7f6f2c75bc49f28"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalNotifications.xcframework.zip",
+          checksum: "51e0a249fe687f95efeff3b3572fc1e9015e24b26a0b35fc2431062d75bf1cf0"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalExtension.xcframework.zip",
-          checksum: "32247475b3f048ed047ecd79f5c1907cbb0ddc8e6e720679cdf24403a3e709e1"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalExtension.xcframework.zip",
+          checksum: "2b90b36465918acfe79b19a09d5057e0d22892c82b9194d2e44e4728c21b2691"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalOutcomes.xcframework.zip",
-          checksum: "a45bb439ef69bca9611e43e14e5e149bf0d4e0c466b744c4b911486036e30f59"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalOutcomes.xcframework.zip",
+          checksum: "900492824e8cd6fd63a220e7ca52a74f8399ac668db2acdaf1c87899761a0c58"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalOSCore.xcframework.zip",
-          checksum: "fa85fcd4560e956ab3544ad0baf6ee5a8a7a7a9623475f149d2b53798759fd74"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalOSCore.xcframework.zip",
+          checksum: "0ff7251680580e87480b0392bd4e7dd1dd93f7d1deabe5d03f30394bb03ea79a"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalCore.xcframework.zip",
-          checksum: "e854226c6630a0ffba2bffe1aadaa34855956a01a6e89f5467663776f1b76f29"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalCore.xcframework.zip",
+          checksum: "ab8bba9dc0410b71b90f56c38ba9c9f5c1caf8172a53f3cb2a34570619f78c43"
         ),
         .binaryTarget(
           name: "OneSignalLiveActivities",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.1/OneSignalLiveActivities.xcframework.zip",
-          checksum: "6abea8e048462ac6c0db4b48a50d86cda53f6c01c55331012fefe575d80aad68"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.2/OneSignalLiveActivities.xcframework.zip",
+          checksum: "a834b4d3b5ce0d8d72679f8798b510a7447789fe14ca55c8a1e3c24ac8fa5530"
         )
     ]
 )


### PR DESCRIPTION
### 🐛 Bug Fixes

- Prevent In-App Message request crashes by making null values safe https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1457
- Add Dispatch Queues to all executors to prevent concurrency crashes https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1454
- Fix clearing notifications incorrectly such as when pulling down the notification center https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1451

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/94)
<!-- Reviewable:end -->
