### PR TITLE
Release 5.2.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -114,53 +114,53 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalFramework.xcframework.zip",
-          checksum: "fe9f32a24a0b557ca91459cd9252382242f5efa1fce3360f5aec2749e31136c1"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalFramework.xcframework.zip",
+          checksum: "5aeb9ece6edb095d851afefcc6c09669fe3e572ab94b747da06349dd124fc4bb"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalInAppMessages.xcframework.zip",
-          checksum: "3f83003276a09e14efbb78d240ef85a01cf3a8edf9548793faf636bb4f39c188"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalInAppMessages.xcframework.zip",
+          checksum: "60100482cee9be64257ccc079a207991284bc257abc4583b24833df0cfd7f4bc"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalLocation.xcframework.zip",
-          checksum: "b7c357aa880bdaff7e404c191f3ea79d82b610e441be99a9bd8c85f861c747df"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalLocation.xcframework.zip",
+          checksum: "e2e04c1b5ef19217ed92583fd427eb6b720d40571ceb974d248c27992f5ad20f"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalUser.xcframework.zip",
-          checksum: "37ca562513890a02bdcccf0ab5f90af404ce7b2876a07f60b765f16c566397bc"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalUser.xcframework.zip",
+          checksum: "c744faade62f0decdba42922affc4a47025c804a3787b5288f7937b082614ce4"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalNotifications.xcframework.zip",
-          checksum: "ad54d5535b980ac17f8351c2f74d51822cf5854f523316aae701d3648050e73b"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalNotifications.xcframework.zip",
+          checksum: "ff8af0ca953d3e973a58b82f88a8201b32a799b5435c4542050789bc183c5c26"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalExtension.xcframework.zip",
-          checksum: "e36eb9f58b9a89881a26fb4e1d004fe5de50aca61bbcf76e0595a61c354d7a81"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalExtension.xcframework.zip",
+          checksum: "50bab1f7d012e1e6a86841f66e3e14925459597c7c0d4abc1132a7d5d4e72af6"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalOutcomes.xcframework.zip",
-          checksum: "7fef845d2beedfa59b2596940a8218568659af22e59434ab188b86e22edc485d"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalOutcomes.xcframework.zip",
+          checksum: "f9970c4e64aab90dd9e354de2bb8daa418eb7365ac43604682d3676e9cde444f"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalOSCore.xcframework.zip",
-          checksum: "2bcc8af026591741849d831594e413702cbdf8feb4fa121ea207840849045ebc"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalOSCore.xcframework.zip",
+          checksum: "33f28e17addbbd57f5626cbef85b6817a1b849be8af718008e5ea8856371c2dd"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalCore.xcframework.zip",
-          checksum: "ed2b9fa04ebc8ae4b1ac8035e410e7a34734dcc1067954b30fc9643eee84ea20"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalCore.xcframework.zip",
+          checksum: "5cab658f2f17394de1b97991307adfb490e474fb0011c8b65ea12da2ba7bdaf4"
         ),
         .binaryTarget(
           name: "OneSignalLiveActivities",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.8/OneSignalLiveActivities.xcframework.zip",
-          checksum: "7194ab56b0b1e31710f7aec7c99c271f54fe0f4071f2240c904565edb4ea8fa9"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.9/OneSignalLiveActivities.xcframework.zip",
+          checksum: "4354ba4df620f61fb677baf06b7a1c4a019651d653f981ce97a88138753ee574"
         )
     ]
 )


### PR DESCRIPTION
## 🐛 Bug Fixes

- [Fix] Use new OneSignalClientError type for callbacks which fixes crash report of `NSInvalidArgumentException` [#1528](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1528)
- [Fix] Don't evaluate in app messages when paused which fixes issues with duration-since-last In-App Messages when pausing and unpausing [#1524](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1524)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-XCFramework/109)
<!-- Reviewable:end -->
