### PR TITLE
Release 5.2.13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -114,53 +114,53 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalFramework.xcframework.zip",
-          checksum: "bf9ae85cb8e8d64e3737997c4b40872c53ae148bb1aadb77d851ab3120f362a2"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalFramework.xcframework.zip",
+          checksum: "514c68370bf6cbbec772aa3373ef0752177aa37002262021238837fb038790a5"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalInAppMessages.xcframework.zip",
-          checksum: "64478d9d33a20c6ea65dfb957f5279ccfd975014c5d0baab3aea7d9ad57e712e"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalInAppMessages.xcframework.zip",
+          checksum: "24de4c1081e9f71de59470827f1abc7ed1eeeab54698761a6d9cefffb0c124e0"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalLocation.xcframework.zip",
-          checksum: "2738b46e6c1a131e8366d6bb8ca257a153145cd7e55db8eb40c9f08de27a8bdc"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalLocation.xcframework.zip",
+          checksum: "51b9ff8e23b6396fd2d877a4ac2e7217e84266c63abfd4d6b26d9ddad06b8c23"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalUser.xcframework.zip",
-          checksum: "8da73babf8fe5b42b0768167ce086def24153133b8ebb8bee8bf0ef47dbb774a"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalUser.xcframework.zip",
+          checksum: "d14580ed7d2c77e24351a2cfdb9d201b87e6dbd7e1a5ec4728287f586660cf9a"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalNotifications.xcframework.zip",
-          checksum: "c7ab266891a3419af290dccca34fd497a5c706412b670feff6eb68fbe610644a"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalNotifications.xcframework.zip",
+          checksum: "7f7e1349d387c56990cd155333efd45061b9ac3127404e41d6e5a85d5abb6793"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalExtension.xcframework.zip",
-          checksum: "d103fc3f7cb2950656dc3cd345830c660a43a3e70ccc7010250fccb864aeb244"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalExtension.xcframework.zip",
+          checksum: "dee412fd139a2ee37755d9184dbe11ee980841046aacb3c1ce208ba6c19772f0"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalOutcomes.xcframework.zip",
-          checksum: "7395842538b69ad0a3d271a6eec63ce4ed11df5cf58d5b8379ea2e47bdfa6bd1"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalOutcomes.xcframework.zip",
+          checksum: "d78458e5863ea346338ef040129919eb8bd2438a0ef77f641327017dd445664a"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalOSCore.xcframework.zip",
-          checksum: "7734389bf8b8bd3e0e5408ba29b9e4fcabb7c17537261a801931ac9a967d6865"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalOSCore.xcframework.zip",
+          checksum: "dbe4901fefa919cadfa1e86a2a88fcc19fbeeea63da1824f1ac378b4d897c959"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalCore.xcframework.zip",
-          checksum: "ec1db495bff47e49099dfdaf741e3839c841903010b13a292790428512f0cf27"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalCore.xcframework.zip",
+          checksum: "9aaf96ac3bd6a898d8c4e8ffc5b0e9dabe6121f783fb89d47142c5f6997247b0"
         ),
         .binaryTarget(
           name: "OneSignalLiveActivities",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.12/OneSignalLiveActivities.xcframework.zip",
-          checksum: "eedecef767619df2b9496340ee23c6063e2f5cc37da084989bcf1223b759b693"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.2.13/OneSignalLiveActivities.xcframework.zip",
+          checksum: "153295a1e182bbc84a7794869813ee90dada6eacd581d1bd3998c0e0697140fb"
         )
     ]
 )


### PR DESCRIPTION
### 🐛 Bug Fixes
- fix(badges): drop deprecated applicationIconBadgeNumber usage (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1568)
- fix(badges): Fix bug when notification has badge set to zero (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1565)