### PR TITLE
Release 5.6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,14 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "OneSignalXCFramework", // Package name MUST be on line 7 for release automation
+    platforms: [
+        .iOS(.v12),
+        .macCatalyst(.v14),
+    ],
     products: [
         .library(
             name: "OneSignalFramework",
@@ -117,53 +121,53 @@ let package = Package(
         ),
         .binaryTarget(
           name: "OneSignalFramework",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalFramework.xcframework.zip",
-          checksum: "c4cc2df16b1944935eae476d4d0510497603f3e69d5d0e2439b772989490538e"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalFramework.xcframework.zip",
+          checksum: "69266cdedd5bbfa2ffd97bcb463dbd082dfabd05462e30ed2948fc3e56f2ff0c"
         ),
         .binaryTarget(
           name: "OneSignalInAppMessages",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalInAppMessages.xcframework.zip",
-          checksum: "a84a7590f53aa29ba232f9f9f4a6ec0c9e507518612b5ffe31c5f64bbc32ea80"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalInAppMessages.xcframework.zip",
+          checksum: "1527a07ebc33abac405f4ae66f7d0a500c7b12c1fb2bd16ce2a171d33ed0fbec"
         ),
         .binaryTarget(
           name: "OneSignalLocation",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalLocation.xcframework.zip",
-          checksum: "385d5bf93c09f5e7bdf85b5f7d162524e995e25db67692dca05112583042c435"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalLocation.xcframework.zip",
+          checksum: "7989998760a81e857018f1714d7797eeb7f083dcc5ab74a02629209b08a5685d"
         ),
         .binaryTarget(
           name: "OneSignalUser",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalUser.xcframework.zip",
-          checksum: "bb7761d4c56eadb7f93d5aea5f919ce9b3768aefd223e85cd91d8b610fb37582"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalUser.xcframework.zip",
+          checksum: "9fb8a58931b3fab3883fd6ed4416bc38998e9734555e267b889b17644f8b9736"
         ),
         .binaryTarget(
           name: "OneSignalNotifications",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalNotifications.xcframework.zip",
-          checksum: "86e2c1a144318c01d02eef0aa9be577e649780ec6009bdcc68133ff48ea86ace"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalNotifications.xcframework.zip",
+          checksum: "e09ce30bc48a1bd013d6113cafc87d3636942eccbcdb0e6ecbf04706b3aa6b67"
         ),
         .binaryTarget(
           name: "OneSignalExtension",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalExtension.xcframework.zip",
-          checksum: "58288d2cea8de2d9fcf6e17aef99a9f4f2ae482cacb9c471ee04060ef763412e"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalExtension.xcframework.zip",
+          checksum: "457bbd44922ee0b5be7d16ae467026c0278e88b2c59467a34c0a4a75d8c53162"
         ),
         .binaryTarget(
           name: "OneSignalOutcomes",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalOutcomes.xcframework.zip",
-          checksum: "52aef6d6abf6cb2bc25bac86a7cc6bc68a5d9d1604e0c981f6b7828b6292946e"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalOutcomes.xcframework.zip",
+          checksum: "5ab21f033b544009fcc5717f0bb750ced1042d2d36ea4b608df45aebe707affc"
         ),
         .binaryTarget(
           name: "OneSignalOSCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalOSCore.xcframework.zip",
-          checksum: "096bb5d068c3e36b0aa5386105045af37f02f9e42ed9c66fd2810e8088dbd1f3"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalOSCore.xcframework.zip",
+          checksum: "f3f950a1016ddc8fd76d1bb6d1dc4004fdb2da1336a3997c1d9c532875076abd"
         ),
         .binaryTarget(
           name: "OneSignalCore",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalCore.xcframework.zip",
-          checksum: "1b7183240403657611f30149e1eecfccf33cfab8a93f8f79316a579e8506d8aa"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalCore.xcframework.zip",
+          checksum: "5eaf8d314ca79f50e165c673784b27bce429ca84f275fa4a2e29493175ad530a"
         ),
         .binaryTarget(
           name: "OneSignalLiveActivities",
-          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.5.6/OneSignalLiveActivities.xcframework.zip",
-          checksum: "a4b63de46ea2878359baa5e388df7307cf10c201d12688ef883b49ce55dd9f3c"
+          url: "https://github.com/OneSignal/OneSignal-iOS-SDK/releases/download/5.6.0/OneSignalLiveActivities.xcframework.zip",
+          checksum: "966729d0827895116e786d62b7c2c900be1a5fec4b0befb3aec4ad9ea11b7b88"
         )
     ]
 )


### PR DESCRIPTION
Channels: Current

### 🚀 New Features

- feat: [SDK-5106] report host app build toolchain on iOS logs (#1728)
- feat: [SDK-5048] call KMP features API and wire flags into OSFeatureManager (#1723)
- feat: [SDK-5047] drive iOS logging from remote params (#1722)
- feat: [SDK-4998] enable KMP logger on Mac Catalyst (#1714)
- feat: [SDK-4978] add iOS KMP crash capture and upload (#1713)
- feat: [SDK-4977] wire KMP remote logging lifecycle (#1703)
- feat: [SDK-4976] add Swift adapters for KMP logger (#1702)

### 🐛 Bug Fixes

- fix: [SDK-5065] report unbuildable log requests as a permanent failure (#1727)
- fix: [SDK-5065] bound the crash-record cache on iOS (#1725)

### ✨ Improvements

- refactor: delegate KMP bumps to shared workflow (#1720)



